### PR TITLE
feat: update CI workflow to build and deploy MkDocs documentation wit…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,4 +28,18 @@ jobs:
           pip install -r requirements.txt
       
       - name: Build and deploy documentation
-        run: mkdocs gh-deploy --force
+        run: |
+          mkdocs build --site-dir ../gh-pages  # Build documentation into the gh-pages directory
+          cd ../gh-pages
+          # We need to disable Jekyll, because gh-pages does not copy files/folders with underscores:
+          # https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/
+          touch .nojekyll  # Prevent GitHub Pages from ignoring files with underscores
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          # git commit returns an error if there are not updates, but this is ok
+          git commit -m "Update MkDocs documentation" -a || true
+      - name: Push documentation changes
+        working-directory: gh-pages
+        run: |
+          git push


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docs.yml` file to enhance the process of building and deploying documentation. The most important changes include modifying the `Build and deploy documentation` job to build the documentation into the `gh-pages` directory and adding a new job to push documentation changes.

Enhancements to documentation deployment:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL31-R45): Modified the `Build and deploy documentation` job to build documentation into the `gh-pages` directory and added steps to configure Git, disable Jekyll, and commit changes.
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL31-R45): Added a new job to push documentation changes from the `gh-pages` directory.…h GitHub Pages