### PR TITLE
feat: update GitHub Actions workflow to build and deploy documentatio…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,19 +27,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       
-      - name: Build and deploy documentation
+      - name: Build documentation
         run: |
-          mkdocs build --site-dir ../gh-pages  # Build documentation into the gh-pages directory
-          cd ../gh-pages
-          # We need to disable Jekyll, because gh-pages does not copy files/folders with underscores:
-          # https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/
-          touch .nojekyll  # Prevent GitHub Pages from ignoring files with underscores
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          # git commit returns an error if there are not updates, but this is ok
-          git commit -m "Update MkDocs documentation" -a || true
-      - name: Push documentation changes
-        working-directory: gh-pages
-        run: |
-          git push
+          mkdocs build --site-dir ./site
+      
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          force_orphan: true
+          publish_branch: gh-pages
+          enable_jekyll: false


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docs.yml` file to streamline the process of building and deploying documentation. The most important changes involve separating the build and deploy steps and utilizing a GitHub Action for deployment.

Improvements to documentation workflow:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL30-R41): Split the "Build and deploy documentation" step into two separate steps: "Build documentation" and "Deploy to GitHub Pages."
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL30-R41): Replaced custom deployment script with `peaceiris/actions-gh-pages@v3` GitHub Action for deploying to GitHub Pages.…n to GitHub Pages