### PR TITLE
feat: update GitHub Actions workflow to set permissions for GitHub Pa…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,12 @@ on:
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,7 +31,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install mkdocs mkdocs-material
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       
       - name: Build documentation
         run: |


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/docs.yml` file to enhance the deployment process of documentation to GitHub Pages. The key changes include setting permissions for the `GITHUB_TOKEN` and modifying the dependency installation process.

Enhancements to GitHub Pages deployment:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR12-R17): Added permissions for the `GITHUB_TOKEN` to allow deployment to GitHub Pages.

Dependency installation improvements:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL28-R35): Changed the dependency installation step to install `mkdocs` and `mkdocs-material` directly, and conditionally install additional requirements if `requirements.txt` exists.…ges deployment