### PR TITLE
feat: remove API key input from frontend and retrieve it from configu…

### DIFF
--- a/docanalyze/api/routes.py
+++ b/docanalyze/api/routes.py
@@ -27,16 +27,19 @@ def analyze_pdf():
         logger.error("No PDF files in request")
         return jsonify({'error': 'No PDF files provided'}), 400
     
-    if 'apiKey' not in request.form:
-        logger.error("No API key in request")
-        return jsonify({'error': 'No API key provided'}), 400
-
     pdf_files = request.files.getlist('pdfFiles')
-    api_key = request.form['apiKey']
     
     if not pdf_files or pdf_files[0].filename == '':
         logger.error("No PDF files selected")
         return jsonify({'error': 'No PDF files selected'}), 400
+    
+    # Get API key from configuration
+    config = get_config()
+    api_key = config.GEMINI_API_KEY
+    
+    if not api_key:
+        logger.error("Gemini API key not configured")
+        return jsonify({'error': 'Server configuration error: Gemini API key not set'}), 500
     
     try:
         # Process each PDF and combine the text

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -165,12 +165,6 @@ document.addEventListener('DOMContentLoaded', function () {
       return;
     }
 
-    const apiKey = document.getElementById('apiKey').value;
-    if (!apiKey) {
-      showError('Please enter your Gemini API key.');
-      return;
-    }
-
     // Show loading and start progress
     loadingSection.style.display = 'flex';
     const progressBar = document.getElementById('progressBar');
@@ -191,10 +185,8 @@ document.addEventListener('DOMContentLoaded', function () {
       formData.append('pdfFiles', files[i]);
     }
 
-    formData.append('apiKey', apiKey);
-
     try {
-      const response = await fetch('/api/analyze', {  // Add the /api prefix
+      const response = await fetch('/api/analyze', {
         method: 'POST',
         body: formData
       });

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,11 +47,6 @@
                         <div class="file-list" id="fileList"></div>
                     </div>
                     <div class="form-group">
-                        <label for="apiKey">Gemini API Key</label>
-                        <input type="password" id="apiKey" name="apiKey" placeholder="Enter your Google Gemini API key"
-                            required>
-                    </div>
-                    <div class="form-group">
                         <button type="submit" id="analyze-btn">Analyze Documents</button>
                     </div>
                 </form>


### PR DESCRIPTION
This pull request includes changes to the `docanalyze/api/routes.py`, `static/js/script.js`, and `templates/index.html` files to remove the requirement for users to provide an API key in the request form. Instead, the API key is now retrieved from the server configuration.

Key changes include:

* **API Key Handling**:
  * [`docanalyze/api/routes.py`](diffhunk://#diff-faecb182d2930afb46adb0a26d7b9e68b775f90b29d0297ef6247bb98d48a0a2L30-R43): Removed the requirement to provide an API key in the request form. The API key is now obtained from the server configuration. Added error handling for missing API key configuration.
  * [`static/js/script.js`](diffhunk://#diff-002e865d16e66912b7c58027ccf63048a101ddfee49617a3c9ece375fe7e1902L168-L173): Removed the code that retrieves the API key from the form and includes it in the request. [[1]](diffhunk://#diff-002e865d16e66912b7c58027ccf63048a101ddfee49617a3c9ece375fe7e1902L168-L173) [[2]](diffhunk://#diff-002e865d16e66912b7c58027ccf63048a101ddfee49617a3c9ece375fe7e1902L194-R189)
  * [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L49-L53): Removed the input field for the API key from the form.…ration in backend