### PR TITLE
Feat/different download formats

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -435,9 +435,50 @@ input:checked+.toggle-slider:before {
     display: none;
 }
 
-/* Download button */
-.download-button {
+/* Download section */
+.download-section {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    justify-content: flex-end;
     margin-top: 20px;
+}
+
+.format-select {
+    padding: 12px;
+    /* Match the button padding */
+    border-radius: 6px;
+    /* Match the button border-radius */
+    border: 1px solid var(--input-border);
+    background-color: var(--input-background);
+    color: var(--text-color);
+    font-size: 0.95rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    height: 44px;
+    /* Match the button height */
+    display: flex;
+    align-items: center;
+}
+
+.format-select:hover {
+    border-color: var(--accent-color);
+}
+
+.format-select:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 2px var(--sun-glow);
+}
+
+/* Download button - remove top margin since it's handled by the section */
+.download-button {
+    margin-top: 0;
+    height: 44px;
+    /* Set fixed height */
+    display: flex;
+    align-items: center;
 }
 
 /* Responsive design */
@@ -515,35 +556,4 @@ input:checked+.toggle-slider:before {
     100% {
         background-position: -200% 0;
     }
-}
-
-/* Download section */
-.download-section {
-    display: flex;
-    gap: 10px;
-    align-items: center;
-    justify-content: flex-end;
-    margin-top: 20px;
-}
-
-.format-select {
-    padding: 8px 12px;
-    border-radius: 4px;
-    border: 1px solid var(--input-border);
-    background-color: var(--input-background);
-    color: var(--text-color);
-    font-size: 0.95rem;
-    font-family: inherit;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.format-select:hover {
-    border-color: var(--accent-color);
-}
-
-.format-select:focus {
-    outline: none;
-    border-color: var(--accent-color);
-    box-shadow: 0 0 0 2px var(--sun-glow);
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -516,3 +516,34 @@ input:checked+.toggle-slider:before {
         background-position: -200% 0;
     }
 }
+
+/* Download section */
+.download-section {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    justify-content: flex-end;
+    margin-top: 20px;
+}
+
+.format-select {
+    padding: 8px 12px;
+    border-radius: 4px;
+    border: 1px solid var(--input-border);
+    background-color: var(--input-background);
+    color: var(--text-color);
+    font-size: 0.95rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.format-select:hover {
+    border-color: var(--accent-color);
+}
+
+.format-select:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 2px var(--sun-glow);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,9 +102,16 @@
                         <div id="recommendations"></div>
                     </div>
 
-                    <button id="download-btn" class="download-button">
-                        <i class="fas fa-download"></i> Download Report
-                    </button>
+                    <div class="download-section">
+                        <select id="download-format" class="format-select">
+                            <option value="txt">Text (.txt)</option>
+                            <option value="md">Markdown (.md)</option>
+                            <option value="pdf">PDF (.pdf)</option>
+                        </select>
+                        <button id="download-btn" class="download-button">
+                            <i class="fas fa-download"></i> Download Report
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This pull request introduces a new feature to the DocAnalyze application that allows users to download analysis reports in multiple formats, including text, markdown, and PDF. The changes span across the backend API routes, frontend JavaScript, CSS, and HTML.

### Backend API changes:
* Added a new endpoint `/convert-to-pdf` to convert HTML content to a PDF using the ReportLab library. This includes creating a buffer, defining styles, parsing HTML-like content, and building the PDF document. (`docanalyze/api/routes.py`) [[1]](diffhunk://#diff-faecb182d2930afb46adb0a26d7b9e68b775f90b29d0297ef6247bb98d48a0a2L4-R13) [[2]](diffhunk://#diff-faecb182d2930afb46adb0a26d7b9e68b775f90b29d0297ef6247bb98d48a0a2R109-R222)

### Frontend JavaScript changes:
* Modified the download button handler to support multiple formats (text, markdown, PDF). For PDF, it sends a request to the new backend endpoint to generate the PDF. (`static/js/script.js`) [[1]](diffhunk://#diff-002e865d16e66912b7c58027ccf63048a101ddfee49617a3c9ece375fe7e1902R305-R393) [[2]](diffhunk://#diff-002e865d16e66912b7c58027ccf63048a101ddfee49617a3c9ece375fe7e1902R402)

### CSS changes:
* Updated styles to accommodate a new download section with a format selector and download button. (`static/css/style.css`)

### HTML changes:
* Added a new download section with a format selector dropdown and a download button to the report generation interface. (`templates/index.html`)